### PR TITLE
Fix duplicate 9 & 10 steps in Windows instructions

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -53,11 +53,11 @@ These instructions were written based on testing with Windows 7, but should work
 
     make
 
-9. If no errors have been produced, then test the 6S executable by typing::
+#. If no errors have been produced, then test the 6S executable by typing::
 
     sixsV1.1 < ..\Examples\Example_In_1.txt
 
-10. If this is working correctly you should see several screen's worth of output, finishing with something that looks like::
+#. If this is working correctly you should see several screen's worth of output, finishing with something that looks like::
 
     *******************************************************************************
     *                        atmospheric correction result                        *


### PR DESCRIPTION
Due to the numbering in the list, the Windows instructions were numbered from 1-10, and then another 9 & 10 followed below.
