### PR TITLE
Reading in cap, xb, xc for reflectance correction

### DIFF
--- a/Py6S/outputs.py
+++ b/Py6S/outputs.py
@@ -166,6 +166,9 @@ class Outputs(object):
                       "coefficients xa": (CURRENT, 5, "coef_xa", float),
                       "coefficients xa xb": (CURRENT, 6, "coef_xb", float),
                       "coefficients xa xb xc": (CURRENT, 7, "coef_xc", float),
+                      "coefficients xap": (CURRENT, 5, "coef_xap", float),
+                      "coefficients xap xb": (CURRENT, 6, "coef_xbp", float),
+                      "coefficients xap xb xc": (CURRENT, 7, "coef_xcp", float),
                       "int. funct filter (in mic)": (1, 0, 'int_funct_filt', float),
                       "int. sol. spect (in w/m2)": (1, 1, 'int_solar_spectrum', float)
                       }


### PR DESCRIPTION
Outputs of 6SV2.1 provide coefficients for the correction of reflectance, which would be useful for doing correction with reflectance data directly instead of converting reflectance to radiance.