### PR TITLE
Bugfix in 6s test

### DIFF
--- a/Py6S/sixs.py
+++ b/Py6S/sixs.py
@@ -360,7 +360,7 @@ class SixS(object):
         """Runs a simple test to ensure that 6S and Py6S are installed correctly."""
         test = cls(path)
         print("6S wrapper script by Robin Wilson")
-        sixs_path = test._find_path()
+        sixs_path = test._find_path(path)
         if sixs_path is None:
             print("Error: cannot find the sixs executable in $PATH or current directory.")
         else:


### PR DESCRIPTION
Currently, the `SixS.test` function doesn't appear to properly use the `path` variable that is passed to it, in the case that the user supplies their own sixs executable.

This PR updates the `_find_path` function called in the test to enable the `path` variable to be passed correctly