### PR TITLE
Don't return OutputParsingError when numpy looks for a __ attribute

### DIFF
--- a/Py6S/outputs.py
+++ b/Py6S/outputs.py
@@ -82,6 +82,8 @@ class Outputs(object):
         """Executed when an attribute is referenced and not found. This method is overridden
         to allow the user to access the outputs as ``outputs.variable`` rather than using the dictionary
         explicity"""
+        if name == "__array_struct__":
+            raise AttributeError()
 
         # If there is a key with this name in the standard variables field then use it
         if name in self.values:


### PR DESCRIPTION
Fixes #76.