### PR TITLE
Remove 'from X import *' imports in the main library and tests

### DIFF
--- a/Py6S/SixSHelpers/all_angles.py
+++ b/Py6S/SixSHelpers/all_angles.py
@@ -20,7 +20,9 @@ import itertools
 from multiprocessing.dummy import Pool
 
 import numpy as np
-from matplotlib.pyplot import *
+from matplotlib.pyplot import plot, show, subplots, xlabel, ylabel
+
+from Py6S import ParameterError
 
 
 class Angles:
@@ -66,7 +68,7 @@ class Angles:
                 a.geometry.solar_a = azimuth
                 a.geometry.solar_z = zenith
             else:
-                raise ParameterException(
+                raise ParameterError(
                     "all_angles",
                     "You must choose to vary either the solar or view angle.",
                 )

--- a/Py6S/SixSHelpers/all_wavelengths.py
+++ b/Py6S/SixSHelpers/all_wavelengths.py
@@ -19,7 +19,7 @@ import copy
 import sys
 
 import numpy as np
-from matplotlib.pyplot import *
+from matplotlib.pyplot import plot, show, xlabel, ylabel
 
 from Py6S.Params import PredefinedWavelengths, Wavelength
 

--- a/Py6S/outputs.py
+++ b/Py6S/outputs.py
@@ -18,7 +18,7 @@
 import pprint
 import sys
 
-from .sixs_exceptions import *
+from .sixs_exceptions import OutputParsingError
 
 
 class Outputs(object):

--- a/Py6S/sixs.py
+++ b/Py6S/sixs.py
@@ -24,9 +24,17 @@ import tempfile
 import numpy as np
 from scipy.interpolate import interp1d
 
-from .outputs import *
-from .Params import *
-from .sixs_exceptions import *
+from .outputs import Outputs
+from .Params import (
+    AeroProfile,
+    Altitudes,
+    AtmosCorr,
+    AtmosProfile,
+    Geometry,
+    GroundReflectance,
+    Wavelength,
+)
+from .sixs_exceptions import ExecutionError, ParameterError
 
 SIXSVERSION = "1.1"
 

--- a/tests/test_6s_examples.py
+++ b/tests/test_6s_examples.py
@@ -19,7 +19,16 @@ import unittest
 
 import numpy as np
 
-from Py6S import *
+from Py6S import (
+    AeroProfile,
+    AtmosCorr,
+    AtmosProfile,
+    Geometry,
+    GroundReflectance,
+    PredefinedWavelengths,
+    SixS,
+    Wavelength,
+)
 
 
 class Example6STests(unittest.TestCase):

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -20,7 +20,17 @@ import unittest
 
 import numpy as np
 
-from Py6S import *
+from Py6S import (
+    AtmosCorr,
+    ExecutionError,
+    Geometry,
+    GroundReflectance,
+    ParameterError,
+    PredefinedWavelengths,
+    SixS,
+    Spectra,
+    Wavelength,
+)
 
 test_dir = os.path.relpath(os.path.dirname(__file__))
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,7 +20,7 @@ import unittest
 
 import numpy as np
 
-from Py6S import *
+from Py6S import AtmosProfile, OutputParsingError, ParameterError, SixS, SixSHelpers
 
 test_dir = os.path.relpath(os.path.dirname(__file__))
 

--- a/tests/test_predefined_wavelengths.py
+++ b/tests/test_predefined_wavelengths.py
@@ -19,7 +19,7 @@ import unittest
 
 import numpy as np
 
-from Py6S import *
+from Py6S import PredefinedWavelengths, SixS, Wavelength
 
 
 class PredefinedWavelengthTests(unittest.TestCase):

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -19,7 +19,7 @@ import unittest
 
 import numpy as np
 
-from Py6S import *
+from Py6S import AeroProfile, AtmosProfile, ParameterError, SixS
 
 
 class AtmosProfileTests(unittest.TestCase):

--- a/tests/test_run_all_wavelengths.py
+++ b/tests/test_run_all_wavelengths.py
@@ -19,7 +19,7 @@ import unittest
 
 import numpy as np
 
-from Py6S import *
+from Py6S import SixS, SixSHelpers
 
 
 class RunAllWavelengthsTests(unittest.TestCase):


### PR DESCRIPTION
This makes for far cleaner code, and was done automatically by the brilliant [removestar](https://www.asmeurer.com/removestar/) library.