### PR TITLE
Remove matplotlib requirement

### DIFF
--- a/Py6S/Params/geometry.py
+++ b/Py6S/Params/geometry.py
@@ -20,7 +20,7 @@ from datetime import timezone
 
 import dateutil.parser
 
-from Py6S import ParameterError
+from ..sixs_exceptions import ParameterError
 
 # Fix for Python 3 where long is not available
 if sys.version_info[0] >= 3:

--- a/Py6S/SixSHelpers/all_angles.py
+++ b/Py6S/SixSHelpers/all_angles.py
@@ -20,9 +20,8 @@ import itertools
 from multiprocessing.dummy import Pool
 
 import numpy as np
-from matplotlib.pyplot import plot, show, subplots, xlabel, ylabel
 
-from Py6S import ParameterError
+from ..sixs_exceptions import ParameterError
 
 
 class Angles:
@@ -106,6 +105,10 @@ class Angles:
         * ``show_sun`` -- (Optional) Whether to show the location of the sun on the resulting polar plot.
         * ``colorbarlabel`` -- (Optional) The label to use on the color bar shown with the plot
         """
+        try:
+            from matplotlib.pyplot import plot, show, subplots, xlabel, ylabel
+        except ImportError:
+            raise ImportError("You must install matplotlib to use the plotting functionality")
 
         results, azimuths, zeniths, sa, sz = data
 

--- a/Py6S/SixSHelpers/all_wavelengths.py
+++ b/Py6S/SixSHelpers/all_wavelengths.py
@@ -19,7 +19,6 @@ import copy
 import sys
 
 import numpy as np
-from matplotlib.pyplot import plot, show, xlabel, ylabel
 
 from Py6S.Params import PredefinedWavelengths, Wavelength
 
@@ -1159,6 +1158,10 @@ class Wavelengths:
           SixSHelpers.PredefinedWavelengths.plot_wavelengths(wavelengths, values, 'Pixel Radiance ($W/m^2$)')
 
         """
+        try:
+            from matplotlib.pyplot import plot, show, xlabel, ylabel
+        except ImportError:
+            raise ImportError("You must install matplotlib to use the plotting functionality")
 
         plot(wavelengths, values, "k")
         xlabel("Wavelength ($\\mu m$)")

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -72,9 +72,9 @@ Python modules
 * ``nose``
 * ``numpy``
 * ``scipy``
-* ``matplotlib``
 * ``python-dateutil``
-* ``pysolar`` v0.6 (optional: only required for setting the geometry from a location and time)
+* ``matplotlib`` (optional: only used for plotting spectra)
+* ``pysolar`` >=0.9 (optional: only required for setting the geometry from a location and time)
 * ``pandas`` (optional: only required for importing AERONET data)
 * ``ipython`` (recommended)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def read_file(filepath, root=PROJECT_ROOT):
 
 LONG_DESCRIPTION = read_file("README.rst")
 SHORT_DESCRIPTION = "A wrapper for the 6S Radiative Transfer Model to make it easy to run simulations with a variety of input parameters, and to produce outputs in an easily processable form."
-REQS = ["pysolar==0.6", "matplotlib", "scipy"]
+REQS = ["pysolar==0.6", "scipy"]
 
 
 setup(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,8 +17,10 @@
 
 import os.path
 import unittest
+import urllib
 
 import numpy as np
+import pytest
 
 from Py6S import AtmosProfile, OutputParsingError, ParameterError, SixS, SixSHelpers
 
@@ -525,10 +527,14 @@ class RadiosondeImportTest(unittest.TestCase):
         s = SixS()
         s.altitudes.set_sensor_satellite_level()
         s.altitudes.set_target_sea_level()
-        s.atmos_profile = SixSHelpers.Radiosonde.import_uow_radiosonde_data(
-            "http://weather.uwyo.edu/cgi-bin/sounding?region=europe&TYPE=TEXT%3ALIST&YEAR=2012&MONTH=02&FROM=2712&TO=2712&STNM=03808",
-            AtmosProfile.MidlatitudeWinter,
-        )
-        s.run()
+        try:
+            s.atmos_profile = SixSHelpers.Radiosonde.import_uow_radiosonde_data(
+                "http://weather.uwyo.edu/cgi-bin/sounding?region=europe&TYPE=TEXT%3ALIST&YEAR=2012&MONTH=02&FROM=2712&TO=2712&STNM=03808",
+                AtmosProfile.MidlatitudeWinter,
+            )
+            s.run()
+        except urllib.error.HTTPError:
+            print("HTTP error in test, skipping")
+            pytest.skip()
 
         self.assertAlmostEqual(s.outputs.apparent_radiance, 164.482, delta=0.02)


### PR DESCRIPTION
Remove hard requirement on matplotlib - make it optional, with an error prompting you to install it if you try and use it don't have it.