### PR TITLE
Adding features to re-use MIE subroutine calculations

### DIFF
--- a/Py6S/Params/aeroprofile.py
+++ b/Py6S/Params/aeroprofile.py
@@ -213,7 +213,7 @@ class AeroProfile:
         comp += " ".join(real) + "\n"
         comp += " ".join(imag) + "\n"
 
-        return header + num + ds + comp + "0 no results saved"
+        return header + num + ds + comp #+ "0 no results saved" 
 
     class AerosolDistribution:
 
@@ -300,7 +300,7 @@ class AeroProfile:
                 len(self.values),
             )
             components = "".join(self.values)
-            return result + components + "0 no results saved"
+            return result + components #+ "0 no results saved"
 
     class UserProfile:
 

--- a/Py6S/Params/aeroprofile.py
+++ b/Py6S/Params/aeroprofile.py
@@ -50,6 +50,24 @@ class AeroProfile:
         return "%d" % type
 
     @classmethod
+    def FromMieFile(cls, mie_file):
+        """Set 6S to use pre-computed outputs of the MIE subroutine written to a text file. 
+           This corresponds to using option iaer=12 in sixs. 
+
+        Arguments:
+
+        * ``mie_file`` -- the name of the text file containing the outputs of the MIE subroutine. 
+
+        Example usage::
+
+          s.aero_profile = AeroProfile.FromMieFile(mie_file = 'FILE.mie')
+
+        """
+        if not mie_file.endswith('.mie'):
+            mie_file = mie_file + '.mie'
+        return "12 from pre-computed mie file\n%s" % mie_file
+
+    @classmethod
     def User(cls, **kwargs):
         """Set 6S to use a user-defined aerosol profile based on proportions of standard aerosol components.
 

--- a/Py6S/sixs.py
+++ b/Py6S/sixs.py
@@ -219,7 +219,10 @@ class SixS(object):
             # - User (string with exactly two lines)
             results_str = "0" 
             if not isinstance(self.aero_profile, AeroProfile.AerosolDistribution):
-                nlines = self.aero_profile.count('\n') 
+                if isinstance(self.aero_profile, int):
+                    nlines=1
+                else:
+                    nlines = self.aero_profile.count('\n') 
             else:
                 nlines = 2
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Py6S.  If not, see <http://www.gnu.org/licenses/>.
 
+import os.path
 import unittest
 
 from Py6S import AeroProfile, AtmosProfile, ParameterError, SixS
@@ -73,6 +74,127 @@ class AeroProfileTests(unittest.TestCase):
                 % (str(aps[i]), s.outputs.apparent_radiance, results[i]),
                 delta=0.002,
             )
+
+    def test_aero_profile_save_mie(self):
+        s = SixS()
+        s.aero_profile = AeroProfile.SunPhotometerDistribution(
+            [
+                0.050000001,
+                0.065604001,
+                0.086076997,
+                0.112939,
+                0.148184001,
+                0.194428995,
+                0.255104989,
+                0.334715992,
+                0.439173013,
+                0.576227009,
+                0.756052017,
+                0.99199599,
+                1.30157101,
+                1.707757,
+                2.24070191,
+                2.93996596,
+                3.85745192,
+                5.06126022,
+                6.64074516,
+                8.71314526,
+                11.4322901,
+                15,
+            ],
+            [
+                0.001338098,
+                0.007492487,
+                0.026454749,
+                0.058904506,
+                0.082712278,
+                0.073251031,
+                0.040950641,
+                0.014576218,
+                0.003672085,
+                0.001576356,
+                0.002422644,
+                0.004472982,
+                0.007452302,
+                0.011037065,
+                0.014523974,
+                0.016981738,
+                0.017641816,
+                0.016284294,
+                0.01335547,
+                0.009732267,
+                0.006301342,
+                0.003625077,
+            ],
+            [1.47] * 20,
+            [0.0093] * 20,
+        )
+        s.mie='test_mie_file'
+        s.run()
+        self.assertEqual(os.path.exists("test_mie_file.mie"), True)
+
+
+    def test_aero_profile_run_mie(self):
+        s = SixS()
+        s.aero_profile = AeroProfile.SunPhotometerDistribution(
+            [
+                0.050000001,
+                0.065604001,
+                0.086076997,
+                0.112939,
+                0.148184001,
+                0.194428995,
+                0.255104989,
+                0.334715992,
+                0.439173013,
+                0.576227009,
+                0.756052017,
+                0.99199599,
+                1.30157101,
+                1.707757,
+                2.24070191,
+                2.93996596,
+                3.85745192,
+                5.06126022,
+                6.64074516,
+                8.71314526,
+                11.4322901,
+                15,
+            ],
+            [
+                0.001338098,
+                0.007492487,
+                0.026454749,
+                0.058904506,
+                0.082712278,
+                0.073251031,
+                0.040950641,
+                0.014576218,
+                0.003672085,
+                0.001576356,
+                0.002422644,
+                0.004472982,
+                0.007452302,
+                0.011037065,
+                0.014523974,
+                0.016981738,
+                0.017641816,
+                0.016284294,
+                0.01335547,
+                0.009732267,
+                0.006301342,
+                0.003625077,
+            ],
+            [1.47] * 20,
+            [0.0093] * 20,
+        )
+        s.mie='test_mie_file'
+        s.run()
+        app_rad = s.outputs.apparent_radiance
+        
+        s.aero_profile = AeroProfile.FromMieFile('test_mie_file')
+        s.run()
+        self.assertAlmostEqual(s.outputs.apparent_radiance, app_rad, delta=0.005)
 
     def test_aero_profile_errors(self):
         with self.assertRaises(ParameterError):


### PR DESCRIPTION
Hi, this pull request adds two features to Py6S:

(1) The ability to save a text file with the `.mie` extension containing the results of the `MIE.f` subroutine (applies only for aerosol profile options 8, 9, 10, and 11). 

To use this, we simply set a new attribute to the SixsS object called `mie` (which by default is set to `None`). By setting it to a string value other than None, then the inputs file will have `1 results saved in X.mie` (where X is the value set to the `mie` attribute) instead of `0 no results saved`, and the following line will have the name of the file (e.g. X). Its value is ignored if the aerosol profile is user-defined (iaer=4) or a predefined type. 

(2) A new classmethod for the `AeroProfile` called `FromMieFile` which will set `iaer` to 12 followed by the name of the text file (provided by the parameter `mie_file`). 

Caveat:

Using a pre-computed MIE file compared to using the options used to create the MIE file will result in some small differences in the output. This is expected because the `AEROSO.f` subroutine writes the text file with a fixed set of precision. 