### PR TITLE
Fix exception with numpy 1.23

### DIFF
--- a/Py6S/outputs.py
+++ b/Py6S/outputs.py
@@ -92,7 +92,7 @@ class Outputs(object):
         """Executed when an attribute is referenced and not found. This method is overridden
         to allow the user to access the outputs as ``outputs.variable`` rather than using the dictionary
         explicity"""
-        if name == "__array_struct__":
+        if name == "__array_struct__" or name == "__array_interface__" or name == "__array__":
             raise AttributeError()
 
         # If there is a key with this name in the standard variables field then use it


### PR DESCRIPTION
Hello,

Due to a recent change in numpy 1.23 (a `DeprecationWarning` is now a proper exception: https://numpy.org/devdocs/release/1.23.0-notes.html#expired-deprecations), an exception is raised in `Wavelengths.run_wavelengths`:

``` bash
Traceback (most recent call last):
  File "venv/lib/python3.9/site-packages/Py6S/SixSHelpers/all_wavelengths.py", line 96, in run_wavelengths
    if len(wavelengths[0]) == 4:
TypeError: object of type 'numpy.float64' has no len()

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
    wv, res = Wavelengths.run_wavelengths(s, self.wvrange, n=ncore)
  File "venv/lib/python3.9/site-packages/Py6S/SixSHelpers/all_wavelengths.py", line 102, in run_wavelengths
    return np.array(wavelengths), np.array(results)
  File "venv/lib/python3.9/site-packages/Py6S/outputs.py", line 113, in __getattr__
    raise OutputParsingError("The specifed output variable does not exist.")
Py6S.sixs_exceptions.OutputParsingError: The specifed output variable does not exist.
```