### PR TITLE
Ignore IEEE_UNDERFLOW_FLAG on MacOS

### DIFF
--- a/Py6S/outputs.py
+++ b/Py6S/outputs.py
@@ -74,6 +74,7 @@ class Outputs(object):
                 (platform.system() == "Darwin")
                 and (not ("IEEE_INVALID_FLAG" in stderr))
                 and (not ("IEEE_DENORMAL" in stderr))
+                and (not ("IEEE_UNDERFLOW_FLAG" in stderr))
             ):  # Ignoring error on MacOS IEEE_INVALID_FLAG
                 print(stderr)
                 raise OutputParsingError(


### PR DESCRIPTION
Added the  IEEE_UNDERFLOW_FLAG to the list of ignored flags in MacOS.

This flags occurs randomly when executting 6S on MacOS on M1 Mac.